### PR TITLE
Add Wiki tab

### DIFF
--- a/dashboard.css
+++ b/dashboard.css
@@ -6,6 +6,10 @@
   display: block;
 }
 
+.filtered-wiki:checked ~ .gollum {
+  display: block;
+}
+
 .filtered-forks:checked ~ .fork {
   display: block;
 }

--- a/dashboard.js
+++ b/dashboard.js
@@ -8,7 +8,7 @@ document.addEventListener('change', function (evt) {
 })
 
 function init () {
-  var events = ['Stars', 'Forks', 'Comments', 'Repositories', 'Issues', 'Org']
+  var events = ['Stars', 'Forks', 'Comments', 'Repositories', 'Issues', 'Org', 'Wiki']
   var target = document.querySelector('.news .alert')
   events.forEach(function (key) {
     var input = document.createElement('input')


### PR DESCRIPTION
`.alert.gollum` is used for wiki edits. By default `dashboard` hides
all wiki edits and doesn't provide a way to show them again. This
PR fixes this by adding a Wiki tab.